### PR TITLE
fix: check_delay_handlerでのS3保存時シリアライズエラーを修正

### DIFF
--- a/python/check_delay_handler/check_delay_handler.py
+++ b/python/check_delay_handler/check_delay_handler.py
@@ -547,7 +547,7 @@ def lambda_handler(event, context):
             s3_client.put_object(
                 Bucket=S3_BUCKET_NAME,
                 Key=DELAY_MESSAGES_FILE_KEY,
-                Body=new_delay_messages_list,
+                Body=json.dumps(new_delay_messages_list, ensure_ascii=False),
             )
         else:
             s3_client.delete_object(


### PR DESCRIPTION
## 概要
CloudWatch Alarmで検知された、Lambda関数  のエラーを修正しました。

## 変更内容
- :
  -  をS3に保存する際、 を使用してPythonオブジェクトからJSON文字列にシリアライズするように修正しました。これにより、AWS SDKの型エラーを解消しました。

## 関連Issue
Close #7