### PR TITLE
fix: 列車遅延チェックLambdaのタイムアウト延長とエラーハンドリング改善

### DIFF
--- a/python/check_delay_handler/check_delay_handler.py
+++ b/python/check_delay_handler/check_delay_handler.py
@@ -29,8 +29,12 @@ ODPT_ACCESS_TOKEN_PARAM_NAME = os.environ.get("ODPT_ACCESS_TOKEN_PARAM_NAME")
 CHALLENGE_ACCESS_TOKEN_PARAM_NAME = os.environ.get("CHALLENGE_ACCESS_TOKEN_PARAM_NAME")
 S3_BUCKET_NAME = os.environ.get("S3_OUTPUT_BUCKET")
 USER_TABLE_NAME = os.environ.get("USER_TABLE_NAME")
-NG_WORD = os.environ.get("NG_WORD")
-RESPONSE_TIMEOUT = int(os.environ.get("RESPONSE_TIMEOUT", "10"))
+NG_WORD = os.environ.get("NG_WORD", "")
+# APIリクエストのタイムアウト設定（秒）
+# connect: サーバーへの接続確立の最大待機時間（ダウン時に早期に判断するため非常に短く設定）
+# read: 接続確立後、レスポンスを受け取るまでの最大待機時間
+CONNECT_TIMEOUT = 2
+READ_TIMEOUT = int(os.environ.get("RESPONSE_TIMEOUT", "15"))
 
 # --- S3オブジェクトキー設定 ---
 USER_LIST_FILE_KEY = "user-list.json"  # 処理対象のユーザーリストが格納されたS3キー
@@ -235,37 +239,45 @@ def get_line_list(s3_lineuserid_list):
 def get_realtime_train_information():
     """リアルタイム運行情報APIを呼び出し、全路線の現在の運行状況を取得する.
 
-    設定された複数のAPIエンドポイントから情報を収集し、結果を一つのリストに結合する。
-
     Returns:
         list | None: 全路線の運行情報のリスト。APIリクエストに失敗した場合はNone。
     """
     logger.info("全てのAPIエンドポイントからリアルタイム運行情報を取得します...")
-    try:
-        realtime_data_list = []
-        for url, token in api_url_token_pairs:
-            logger.info(f"APIエンドポイントを呼び出します: {url}")
-            params = {"acl:consumerKey": token}
+    realtime_data_list = []
+    success_count = 0
+    
+    for url, token in api_url_token_pairs:
+        logger.info(f"APIエンドポイントを呼び出します: {url}")
+        params = {"acl:consumerKey": token}
 
-            response = requests.get(url, params=params, timeout=RESPONSE_TIMEOUT)
-            response.raise_for_status()  # HTTPエラーがあれば例外を発生させる
+        try:
+            # 接続(connect)は2秒、読み取り(read)は環境変数の値(約15~30秒)でタイムアウト設定
+            response = requests.get(url, params=params, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT))
+            response.raise_for_status()
 
             response_data = response.json()
             realtime_data_list.extend(response_data)
-            logger.debug(
-                f"{len(response_data)} 件のレコードを取得しました。",
+            success_count += 1
+            logger.info(
+                f"URL {url} から {len(response_data)} 件のレコードを取得しました。",
                 extra={"url": url, "record_count": len(response_data)},
             )
+        except requests.exceptions.RequestException as e:
+            # 片方のAPIが死んでいても、もう片方でデータが取れていれば「致命的なエラー」とはしない
+            logger.warning(
+                f"APIエンドポイント {url} が応答しません。このソースはスキップします: {e}",
+                extra={"url": url}
+            )
 
-        logger.info(
-            f"取得完了。合計 {len(realtime_data_list)} 件のレコードを取得しました。",
-            extra={"total_record_count": len(realtime_data_list)},
-        )
-        return realtime_data_list
-
-    except requests.exceptions.RequestException:
-        logger.error("APIへのリクエストに失敗しました。", exc_info=True)
+    if not realtime_data_list and success_count == 0:
+        logger.error("すべてのAPIエンドポイントからのデータ取得に失敗しました。")
         return None
+
+    logger.info(
+        f"運行情報の取得が完了しました。合計 {len(realtime_data_list)} 件のレコードを処理します。",
+        extra={"total_record_count": len(realtime_data_list)},
+    )
+    return realtime_data_list
 
 
 def create_snd_message(user_route, message):
@@ -407,8 +419,12 @@ def delay_check(user_route_list, realtime_data_list, railway_list, s3_delay_list
 
         # 鉄道名に一致するリアルタイム運行情報を検索
         for realtime_data in realtime_data_list:
-            if realtime_data["odpt:railway"] == user_route_id:
-                message = realtime_data["odpt:trainInformationText"]["ja"]
+            if realtime_data.get("odpt:railway") == user_route_id:
+                info_text = realtime_data.get("odpt:trainInformationText", {})
+                if isinstance(info_text, dict):
+                    message = info_text.get("ja", "")
+                else:
+                    message = str(info_text) if info_text else ""
                 break
         if not message:
             logger.warning(

--- a/terraform/cloudwatch_logs.tf
+++ b/terraform/cloudwatch_logs.tf
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------
 resource "aws_cloudwatch_log_group" "user_settings_lambda_lg" {
   # ロググループ名 (Lambdaの標準形式に合わせる)
-  name              = "/aws/lambda/${local.name_prefix}-lambda-user-settings"
+  name = "/aws/lambda/${local.name_prefix}-lambda-user-settings"
   # ログの保持期間 (日)
   retention_in_days = 1
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -80,7 +80,7 @@ resource "aws_lambda_function" "check_delay_lambda" {
   function_name = "${local.name_prefix}-lambda-check-delay"
   handler       = "check_delay_handler.lambda_handler"
   runtime       = var.lambda_runtime_version[0]
-  timeout       = var.lambda_timeout_seconds
+  timeout       = max(var.lambda_timeout_seconds, 60)
   memory_size   = var.lambda_memory_size
   role          = aws_iam_role.lambda_exec_role.arn
 
@@ -100,7 +100,7 @@ resource "aws_lambda_function" "check_delay_lambda" {
       TRAIN_STATUS_TABLE_NAME           = aws_dynamodb_table.train_status.name
       USER_TABLE_NAME                   = aws_dynamodb_table.users.name
       NG_WORD                           = var.ng_word[0]
-      RESPONSE_TIMEOUT                  = var.response_timeout
+      RESPONSE_TIMEOUT                  = max(var.response_timeout, 55)
     }
   }
 

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -14,13 +14,13 @@ resource "aws_sns_topic" "sns_topic_system" {
   delivery_policy = jsonencode({
     "http" : {
       "defaultHealthyRetryPolicy" : {
-        "minDelayTarget"     : 20,
-        "maxDelayTarget"     : 20,
-        "numRetries"         : 3,
+        "minDelayTarget" : 20,
+        "maxDelayTarget" : 20,
+        "numRetries" : 3,
         "numMaxDelayRetries" : 0,
-        "numNoDelayRetries"  : 0,
+        "numNoDelayRetries" : 0,
         "numMinDelayRetries" : 0,
-        "backoffFunction"    : "linear"
+        "backoffFunction" : "linear"
       },
       "disableSubscriptionOverrides" : false,
       "defaultThrottlePolicy" : {


### PR DESCRIPTION
## 概要
CloudWatchアラームで大量に通知されていたLambdaのタイムアウトエラーとKeyErrorを修正しました。

## 変更内容
- **Lambdaタイムアウトの延長**: 10秒から60秒に延長し、外部APIの応答遅延による強制終了を防止。
- **リクエストタイムアウトの最適化**: 
  - 接続タイムアウト（Connect）を2秒に短縮し、ダウンしているAPIを即座にスキップ可能に。
  - 読み取りタイムアウト（Read）を55秒に設定。
- **エラーハンドリングの強化**:
  - 複数のAPIエンドポイントの内、一部が死んでいても他の正常なエンドポイントから情報を取得し続けられるように修正。
- **堅牢性の向上**: APIレスポンス内の `odpt:railway` 等のキーが欠落していた場合に発生する `KeyError` を防ぐガード節を追加。

## 動作確認結果
- 本番環境（profile: portfolio-prd）への手動デプロイおよびテスト実行にて、`api-challenge.odpt.org` がダウンしていても2秒でスキップされ、全体の処理が約3秒で正常終了（StatusCode: 200）することを確認済み。
